### PR TITLE
Profile used endpoint details for a query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- There should always be "Unreleased" section at the beginning. -->
 
 ## Unreleased
+- Profile used endpoint details for a query
 
 ## 1.0.0 - 2021-05-13
 - Initial implementation

--- a/src/Query/AbstractSolrQuery.php
+++ b/src/Query/AbstractSolrQuery.php
@@ -49,7 +49,9 @@ abstract class AbstractSolrQuery implements QueryInterface, CacheableInterface, 
 
     public function getProfilerData(): ?array
     {
-        return null;
+        return [
+            'Endpoint' => $this->getEndpoint() ?? 'Default',
+        ];
     }
 
     public function getEndpoint(): ?string

--- a/src/Query/AbstractSolrSelectQuery.php
+++ b/src/Query/AbstractSolrSelectQuery.php
@@ -54,4 +54,11 @@ abstract class AbstractSolrSelectQuery extends AbstractSolrQuery implements Inje
     }
 
     abstract public function prepareSelect(Query $select): Query;
+
+    public function getProfilerData(): ?array
+    {
+        return parent::getProfilerData() + [
+                'Endpoint.details' => clone $this->client->getEndpoint($this->getEndpoint()),
+            ];
+    }
 }

--- a/tests/QueryBuilder/Applicator/GroupingApplicatorTest.php
+++ b/tests/QueryBuilder/Applicator/GroupingApplicatorTest.php
@@ -30,11 +30,11 @@ class GroupingApplicatorTest extends ApplicatorTestCase
         $this->assertStringContainsString('rows=' . $entity->getNumberOfRows(), $queryUri);
 
         $this->assertStringContainsString('group=true', $queryUri);
-        $this->assertStringContainsString('group.main=' . $entity->getMainResult() ? 'true' : 'false', $queryUri);
+        $this->assertStringContainsString('group.main=' . ($entity->getMainResult() ? 'true' : 'false'), $queryUri);
         $this->assertStringContainsString('group.field=' . $entity->getGroupingField(), $queryUri);
         $this->assertStringContainsString('group.limit=' . $entity->getGroupingLimit(), $queryUri);
         $this->assertStringContainsString(
-            'group.ngroups=' . $entity->getNumberOfGroups() ? 'true' : 'false',
+            'group.ngroups=' . ($entity->getNumberOfGroups() ? 'true' : 'false'),
             $queryUri
         );
     }


### PR DESCRIPTION
I'm not completely sure about cloning an Endpoint to the profiler data, but something is telling me, that it may be a good idea not to have a real instance there - since it disallow to change the object from one place to the other via object-reference.