### PR TITLE
Allow initiator in response decoder supports method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- There should always be "Unreleased" section at the beginning. -->
 
 ## Unreleased
+- [**BC**] Add an `$initiator` to `ResponseDecoders` `supports` method
 
 ## 1.1.0 - 2021-07-28
 - Profile used endpoint details for a query

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.4",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "lmc/cqrs-types": "^1.0",
+        "lmc/cqrs-types": "^2.0",
         "nelmio/solarium-bundle": "^4.0",
         "solarium/solarium": "^5.2"
     },


### PR DESCRIPTION
This only allows a new version of the cqrs-types so this library could be used in cqrs-bundle.